### PR TITLE
fix(deps): bump Pygments to 2.20.0 (ReDoS)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1554,11 +1554,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631 }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217 },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151 },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Bumps **Pygments** `2.19.2 → 2.20.0` in `uv.lock`.

## Why

Resolves Dependabot alert #4 (**low**): Pygments < 2.20.0 has a ReDoS via an inefficient GUID-matching regex (GHSA-5239-wwwm-4pmq).

Pygments is a **transitive dev dependency** (via `pytest`) — **no runtime impact** on the published wheel; `warp_cache`'s only runtime dependency is `typing_extensions`. Exposure is limited to the dev/CI environment.

## Scope

Lock-only change; 3.9-compatible, no source or API changes.

The other Dependabot alerts (pillow → #58, pytest → #59) are **blocked by Python 3.9 support** (their patched versions require ≥ 3.10) and tracked separately.

## Verification

- `uv lock --check` — consistent
- `ruff check` + `ty check` — clean
- `maturin develop` + `pytest` — **79 passed**

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)