### PR TITLE
ci: track benchmark trends across the Python/OS matrix (#62)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,89 @@
+name: Benchmark trends
+
+# Trend tracking only (no PR gating) — runs on master pushes so the gh-pages
+# history reflects merged code. Manual runs via workflow_dispatch.
+# ponytail: master-only by design. If you ever want per-PR perf numbers, add
+# `pull_request:` here and gate the publish job on event_name == 'push'.
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  bench:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Linux x86_64 — full version sweep (Python version moves perf most)
+          - { os: ubuntu-latest, python-version: "3.9" }
+          - { os: ubuntu-latest, python-version: "3.10" }
+          - { os: ubuntu-latest, python-version: "3.11" }
+          - { os: ubuntu-latest, python-version: "3.12" }
+          - { os: ubuntu-latest, python-version: "3.13" }
+          - { os: ubuntu-latest, python-version: "3.14" }
+          # Linux arm64 — boundary versions
+          - { os: ubuntu-24.04-arm, python-version: "3.9" }
+          - { os: ubuntu-24.04-arm, python-version: "3.14" }
+          # macOS arm64 — boundary versions
+          - { os: macos-latest, python-version: "3.9" }
+          - { os: macos-latest, python-version: "3.14" }
+          # Windows excluded: bench-quick runs shared-memory/multiprocess steps
+          # that don't run on Windows (same reason the test job skips them there).
+    runs-on: ${{ matrix.os }}
+    env:
+      TAG: ${{ matrix.os }}-py${{ matrix.python-version }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: bench-${{ matrix.os }}-py${{ matrix.python-version }}
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+      - name: Install build deps
+        run: uv pip install maturin
+      - name: Build extension
+        run: uv run maturin develop --release
+      - name: Run benchmarks (quick)
+        run: uv run python benchmarks/_bench_runner.py --tag "$TAG" --quick
+      - name: Convert to action format
+        run: uv run python benchmarks/_to_action_json.py "benchmarks/results/bench_$TAG.json" "bench-action-$TAG.json" --tag "$TAG"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: bench-action-${{ matrix.os }}-py${{ matrix.python-version }}
+          path: bench-action-${{ env.TAG }}.json
+          if-no-files-found: error
+
+  publish:
+    needs: bench
+    runs-on: ubuntu-latest
+    # Single push to gh-pages from one job — matrix cells must NOT each push
+    # (concurrent gh-pages pushes race). They upload artifacts; we merge here.
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: bench-action-*
+          path: bench-artifacts
+          merge-multiple: true
+      - name: Merge all cells into one series file
+        run: jq -s 'add' bench-artifacts/*.json > combined.json
+      - name: Publish to gh-pages (trend charts)
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: warp_cache benchmarks
+          tool: customBiggerIsBetter
+          output-file-path: combined.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench
+          auto-push: true
+          fail-on-alert: false # trend tracking only — never gate on noisy CI numbers

--- a/benchmarks/_to_action_json.py
+++ b/benchmarks/_to_action_json.py
@@ -1,0 +1,72 @@
+"""Convert a bench_<tag>.json payload into github-action-benchmark's
+``customBiggerIsBetter`` format (a flat list of {name, unit, value}).
+
+Reuses the existing runner output (benchmarks/_bench_runner.py); we only pull a
+few headline warp_cache metrics, each tagged with the env so every matrix cell
+becomes its own trend series.
+
+Usage:
+    python _to_action_json.py <bench_results.json> <out.json> --tag ubuntu-py3.13
+    python _to_action_json.py --selftest
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# (payload section, key, label) — headline warp_cache series to track.
+# ponytail: two metrics is enough to spot trends; add more when a chart is missed.
+METRICS = [
+    ("throughput", "1024", "single-thread throughput (size=1024)"),
+    ("threading", "8", "throughput (8 threads)"),
+]
+
+
+def convert(payload: dict, tag: str) -> list[dict]:
+    out = []
+    for section, key, label in METRICS:
+        value = payload.get(section, {}).get(key, {}).get("warp_cache")
+        if value is None:
+            continue  # impl/section absent in this run; skip rather than emit junk
+        out.append({"name": f"warp_cache {label} [{tag}]", "unit": "ops/s", "value": round(value)})
+    return out
+
+
+def _selftest() -> None:
+    sample = {
+        "throughput": {"1024": {"warp_cache": 1000.4}},
+        "threading": {"8": {"warp_cache": 500.0}},
+    }
+    out = convert(sample, "x-pyY")
+    assert [m["value"] for m in out] == [1000, 500], out
+    assert all(m["unit"] == "ops/s" and "x-pyY" in m["name"] for m in out), out
+    assert convert({}, "t") == []  # missing data -> empty, not a crash
+    print("selftest ok")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("infile", nargs="?", help="bench_<tag>.json from the runner")
+    p.add_argument("outfile", nargs="?", help="output JSON path")
+    p.add_argument("--tag", default="", help="env label, e.g. ubuntu-latest-py3.13")
+    p.add_argument("--selftest", action="store_true")
+    args = p.parse_args()
+
+    if args.selftest:
+        _selftest()
+        return
+    if not (args.infile and args.outfile):
+        p.error("infile and outfile are required (or pass --selftest)")
+
+    payload = json.loads(Path(args.infile).read_text())
+    metrics = convert(payload, args.tag)
+    if not metrics:
+        print(f"no warp_cache metrics found in {args.infile}", file=sys.stderr)
+        sys.exit(1)
+    Path(args.outfile).write_text(json.dumps(metrics, indent=2))
+    print(f"wrote {len(metrics)} metric(s) to {args.outfile}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #62

## What & why
Adds `.github/workflows/bench.yml` to record warp_cache's performance over time across the supported Python versions and OSes. Today the benchmark suite only runs locally/ad-hoc; this gives a historical trend on gh-pages.

## How
- **Trigger:** `push` to `master` + `workflow_dispatch`. *Not* on PRs — keeps PRs fast; trends are a master-timeline concern.
- **Matrix (~10 cells):** ubuntu 3.9–3.14 + arm64/macOS boundary versions. **Windows excluded** — `bench-quick` runs the shared-memory/multiprocess steps, which don't run on Windows (same reason the test job ignores those tests there).
- **Per cell:** build (`maturin develop --release`) → `bench-quick` → convert headline warp_cache metrics to `github-action-benchmark`'s `customBiggerIsBetter` format → upload artifact.
- **Publish job:** merges all artifacts (`jq -s add`) and pushes **once** to `gh-pages` via `benchmark-action/github-action-benchmark`. Matrix cells deliberately do **not** each push — concurrent gh-pages pushes would race.
- **Trend tracking only — no regression gating** (`fail-on-alert: false`). Shared CI runners are too noisy to gate ns-level microbenchmarks without flaky failures.
- Reuses the existing runner output via a small converter (`benchmarks/_to_action_json.py`); no bench-logic rewrite.

## One-time setup
- An orphan `gh-pages` branch (the action can create it on first `auto-push`). The publish job has `contents: write`; all other jobs stay read-only.

## Verified locally
- `benchmarks/_to_action_json.py --selftest` passes; runs on a real `bench_*.json` payload and emits the expected `customBiggerIsBetter` JSON; `jq -s add` merge produces the combined series.
- `bench.yml` parses (2 jobs, 10 matrix cells); `ruff check benchmarks/` and `ty check` clean.
- The full workflow (artifact round-trip + gh-pages push) can only be exercised by CI on merge — no Rust/package/test code is touched.

## Scope note
Independent of the reentrancy PR (#61); separate issue/branch per the repo's pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)