### PR TITLE
fix: reject max_size=0 on shared backend to prevent OOB slab access (#31)

### DIFF
--- a/src/shared_store.rs
+++ b/src/shared_store.rs
@@ -62,6 +62,12 @@ impl SharedCachedFunction {
         max_value_size: usize,
         shm_name: Option<String>,
     ) -> PyResult<Self> {
+        if max_size == 0 {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "max_size must be >= 1 for the shared backend",
+            ));
+        }
+
         let pickle = py.import("pickle")?;
         let pickle_dumps = pickle.getattr("dumps")?.unbind();
         let pickle_loads = pickle.getattr("loads")?.unbind();

--- a/src/shm/region.rs
+++ b/src/shm/region.rs
@@ -38,6 +38,17 @@ impl ShmRegion {
         max_value_size: u32,
         ttl_nanos: u64,
     ) -> io::Result<Self> {
+        // ponytail: capacity==0 makes a zero-slot slab while free_head stays 0,
+        // so the first insert dereferences a slot one-past-the-end of the mmap
+        // (OOB read+write). Reject at the unsafe boundary so the region can never
+        // be constructed unsound, regardless of caller. See issue #31.
+        if capacity == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "shared cache capacity (max_size) must be >= 1",
+            ));
+        }
+
         let dir = shm_dir();
         if !dir.exists() {
             fs::create_dir_all(&dir)?;
@@ -211,5 +222,4 @@ impl ShmRegion {
     pub fn base_ptr(&self) -> *const u8 {
         self.mmap.as_ptr()
     }
-
 }

--- a/tests/test_shared_basic.py
+++ b/tests/test_shared_basic.py
@@ -5,6 +5,8 @@ import glob
 import os
 import tempfile
 
+import pytest
+
 from warp_cache import SharedCacheInfo, cache
 
 
@@ -330,3 +332,29 @@ class TestSharedMemoryBackend:
         info = fn.cache_info()
         assert isinstance(info, SharedCacheInfo)
         assert hasattr(info, "oversize_skips")
+
+
+class TestSharedMaxSizeZero:
+    """Regression for #31: max_size=0 on the shared backend used to build a
+    zero-slot slab and read+write out of bounds on the first insert."""
+
+    def setup_method(self):
+        _cleanup_shm()
+
+    def teardown_method(self):
+        _cleanup_shm()
+
+    def test_max_size_zero_raises(self):
+        with pytest.raises(ValueError, match="max_size must be >= 1"):
+
+            @cache(max_size=0, backend="shared")
+            def fn(x):
+                return x
+
+    def test_max_size_one_is_usable(self):
+        @cache(max_size=1, backend="shared")
+        def fn(x):
+            return x * 2
+
+        assert fn(3) == 6
+        assert fn(3) == 6


### PR DESCRIPTION
## What & why

`@cache(max_size=0, backend="shared")` was a memory-safety landmine. With `max_size=0`:

- `ht_capacity = (0*2).next_power_of_two() = 1` → a 1-bucket hash table,
- the slab init loop `for i in 0..0` runs zero times → **no slots exist**,
- but `header.free_head` is unconditionally set to `0`.

On the **first call**, `insert_inner` takes the free-list branch (`free_head(0) != SLOT_NONE`), dereferences `slab_base + 0*slot_size` — a `SlotHeader` one element **past the end** of the 272-byte mmap — then writes the full header + key + value there. That's an **out-of-bounds read and write reachable entirely from safe Python**.

## Fix

Reject `capacity == 0` at two layers:

| Layer | Guard | Purpose |
|-------|-------|---------|
| `SharedCachedFunction::new` (PyO3 boundary) | `PyValueError` | Clean, correct error type for the public API — the only shared-backend entry point, so it can't be bypassed from Python. |
| `ShmRegion::create` (unsafe core) | `io::Error(InvalidInput)` | Hardens the `unsafe` region so it can never be constructed unsound, regardless of caller. |

The **memory backend** path (`max_size=0` semantics — separate issue #47) is deliberately left untouched; this change is scoped to the shared backend's memory-safety hole.

## Tests

- `test_max_size_zero_raises` — `@cache(max_size=0, backend="shared")` now raises `ValueError` (segfaulted before the fix).
- `test_max_size_one_is_usable` — `max_size=1` still works (boundary sanity).

## Gates run

- `make fmt` / `make lint` (ruff, ty, clippy `-D warnings`) — clean.
- `make test` (cargo test + full pytest) — **86 passed**.
- **Risky change** (touches `src/shm/` + PyO3 boundary): serial Python matrix **3.9–3.13 — 86 passed each**.
- Skipped `make bench`: this is a construction-time guard with no hot-path/eviction surface.

> ⚠️ Note: Python **3.14** segfaults locally during pytest collection at `tests/test_shared_multiprocess.py:31` (module-level `SharedCachedFunction(...)` construction). **This reproduces on `master` without this change** — it is pre-existing and out of scope here. Worth a separate issue.

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)