### PR TITLE
fix: make test-matrix serial and skip prerelease interpreters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ A change is **risky** if it touches any of:
 For risky changes, additionally run and report:
 
 ```bash
-make test-matrix -j     # Python 3.9–3.14
+make test-matrix        # Python 3.9–3.14 (serial; prereleases skipped)
 make bench              # or: make bench-sieve  for eviction-quality changes
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ reproduction.
 ```bash
 make test              # Build + run all tests
 make test-only         # Run tests without rebuilding
-make test-matrix       # Test across Python 3.9-3.14 (serial; prereleases skipped)
+make test-matrix       # Test across Python 3.10-3.14 (serial; prereleases skipped)
 uv run pytest tests/test_basic.py::test_cache_hit -v  # Run a single test
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ reproduction.
 ```bash
 make test              # Build + run all tests
 make test-only         # Run tests without rebuilding
-make test-matrix -j    # Test across Python 3.10-3.14
+make test-matrix       # Test across Python 3.9-3.14 (serial; prereleases skipped)
 uv run pytest tests/test_basic.py::test_cache_hit -v  # Run a single test
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -42,12 +42,21 @@ test: build test-rust ## Build and run tests
 	uv run $(UV_PYTHON) pytest tests/ -v
 
 
-TEST_TARGETS := $(addprefix test-py-,$(SUPPORTED_PYTHONS))
-test-matrix: $(TEST_TARGETS) ## Run tests for multiple Python versions (parallel with -j)
-
-test-py-%:
-	@echo "==> Testing with Python $*"
-	@$(MAKE) test PYTHON=$*
+# Runs serially on purpose: every version repoints the shared .venv, and the
+# shared-backend tests all use one process-wide shm dir (/tmp/warp_cache or
+# /dev/shm) with fixed names — running versions concurrently (-j) clobbers both.
+# Prereleases are skipped with a warning: their ABI is incompatible with PyO3
+# and segfault instead of failing cleanly (e.g. a stale 3.14.0aN that uv resolves
+# for `--python 3.14`). CI tests the real finals via setup-python.
+test-matrix: ## Run the test suite across all supported Python versions (serial)
+	@for v in $(SUPPORTED_PYTHONS); do \
+		echo "==> Testing with Python $$v"; \
+		if ! uv run --python $$v --no-project python -c "import sys; sys.exit(0 if sys.version_info.releaselevel == 'final' else 1)"; then \
+			echo "WARNING: skipping Python $$v — 'uv run --python $$v' resolved to a prerelease ($$(uv run --python $$v --no-project python -c 'import sys; print(sys.version.split()[0])')); its ABI breaks PyO3. Install a stable build: uv python install $$v"; \
+			continue; \
+		fi; \
+		$(MAKE) test PYTHON=$$v || exit 1; \
+	done
 
 test-only: ## Run tests without rebuilding
 	uv run $(UV_PYTHON) pytest tests/ -v


### PR DESCRIPTION
Resolves the two issues flagged during the #31 work (no separate tickets, per maintainer).

## Problem 1 — `make test-matrix -j` corrupts the venv

Every `test-py-<ver>` target ran `uv run --python <ver> maturin develop`, but all versions share the **single project `.venv`** — each `uv run --python X` repoints it. Under `-j` the parallel runs race and leave `.venv` broken (`not a valid Python environment, no Python executable found`), failing the whole matrix.

There's a second `-j` hazard: the shared-backend tests all use **one process-wide shm dir** (`/tmp/warp_cache`, `/dev/shm`) with fixed names, and `setup/teardown` wipe it — so concurrent versions clobber each other's mmap files. Truly parallelizing would need a Rust change to make the shm dir configurable (out of scope).

**Fix:** run the matrix **serially** via a single loop (immune to `-j`). Sequential runs contend neither the venv nor the shm dir. Simpler than per-version venvs and correct on both axes.

## Problem 2 — Python 3.14 segfaults locally

`make test PYTHON=3.14` segfaulted at the first `SharedCachedFunction(...)` construction (pytest collection). Root cause: `uv run --python 3.14` resolves to a **stale `3.14.0a6` alpha** in uv's managed pythons, and the alpha's ABI is incompatible with **PyO3 0.29** (SIGSEGV). 

- ✅ Verified the extension is **correct on 3.14.3 final** (constructs, calls, caches — exit 0).
- ❌ The `3.14.0a6` alpha segfaults (exit 139).
- CI uses `actions/setup-python@3.14` → real finals, so **CI was never affected**. Reproduced on `master`, so it was never a regression.

**Fix:** the matrix **skips prerelease interpreters with a clear warning** (and the `uv python install <ver>` hint) instead of letting them segfault. No code change — chasing alpha ABIs would be wrong; 3.14 final works.

## Verification

```
$ make test-matrix
==> Testing with Python 3.9   → 84 passed   (+ cargo: 11 passed)
==> Testing with Python 3.10  → 84 passed
==> Testing with Python 3.11  → 84 passed
==> Testing with Python 3.12  → 84 passed
==> Testing with Python 3.13  → 84 passed
==> Testing with Python 3.14
WARNING: skipping Python 3.14 — 'uv run --python 3.14' resolved to a prerelease (3.14.0a6); its ABI breaks PyO3. Install a stable build: uv python install 3.14
```

`make lint` and `make test` clean.

## Docs

Dropped the misleading `-j` from CLAUDE.md and CONTRIBUTING.md. Supported-version ranges are left unchanged here — dropping Python 3.9 (and the doc-range correctness that #55 tracks) is owned by the separate drop-3.9 PR #67.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
