### PR TITLE
fix: fall back to pickle for non-UTF8 strings instead of raising (#34)

### DIFF
--- a/src/serde.rs
+++ b/src/serde.rs
@@ -94,7 +94,13 @@ fn serialize_element(_py: Python, obj: &Bound<PyAny>, buf: &mut Vec<u8>) -> PyRe
 
     // str
     if obj.is_instance_of::<PyString>() {
-        let s = obj.cast::<PyString>()?.to_cow()?;
+        // to_cow() errors for strings that aren't valid UTF-8 (lone surrogates,
+        // e.g. from os.fsdecode of non-UTF8 paths). They can't go through the
+        // UTF-8 fast path, so fall back to pickle (which handles them) instead
+        // of propagating UnicodeEncodeError out of the cached call.
+        let Ok(s) = obj.cast::<PyString>()?.to_cow() else {
+            return Ok(false);
+        };
         let bytes = s.as_bytes();
         buf.push(TAG_STR);
         buf.extend_from_slice(&(bytes.len() as u32).to_le_bytes());

--- a/tests/test_complex_objects.py
+++ b/tests/test_complex_objects.py
@@ -320,6 +320,22 @@ class TestSharedComplexValues:
         assert result["list"] == list(range(100))
         assert mixed() == result
 
+    def test_surrogate_string_value(self):
+        # Lone surrogates are valid Python str but not UTF-8 encodable; the
+        # fast path must fall back to pickle instead of raising (issue #34).
+        call_count = 0
+
+        @cache(max_size=16, backend="shared")
+        def make(_):
+            nonlocal call_count
+            call_count += 1
+            return "head\ud800tail"
+
+        result = make(0)
+        assert result == "head\ud800tail"
+        assert make(0) == result
+        assert call_count == 1
+
 
 @_skip_on_windows
 class TestSharedComplexKeys:
@@ -383,4 +399,36 @@ class TestSharedComplexKeys:
         fs = frozenset(range(200))
         assert count(fs) == 200
         assert count(fs) == 200
+        assert call_count == 1
+
+    def test_surrogate_string_key(self):
+        # A lone-surrogate string argument must serialize (via pickle fallback)
+        # and hit the cache instead of raising UnicodeEncodeError (issue #34).
+        call_count = 0
+
+        @cache(max_size=16, backend="shared")
+        def echo(s):
+            nonlocal call_count
+            call_count += 1
+            return len(s)
+
+        sur = "\ud800"
+        assert echo(sur) == 1
+        assert echo(sur) == 1
+        assert call_count == 1
+
+    def test_surrogate_string_in_tuple_key(self):
+        # Surrogate nested in a tuple exercises the tuple serialize path, as
+        # both key and value (issue #34).
+        call_count = 0
+
+        @cache(max_size=16, backend="shared")
+        def f(t):
+            nonlocal call_count
+            call_count += 1
+            return t
+
+        key = ("ok", "\udfff", 3)
+        assert f(key) == key
+        assert f(key) == key
         assert call_count == 1


### PR DESCRIPTION
## Problem

The shared backend's fast-path string serializer (`src/serde.rs`) did:

```rust
let s = obj.cast::<PyString>()?.to_cow()?;
```

`to_cow()` returns `UnicodeEncodeError` for valid Python `str` values that aren't UTF-8 encodable — **lone surrogates**, e.g. from `os.fsdecode` of non-UTF8 filesystem paths or `surrogateescape` decoding. The `?` propagated that error past the pickle fallback in `serialize()`/`serialize_element()`, so a perfectly cacheable call **raised `UnicodeEncodeError` instead of caching**.

The fast-path contract is that unsupported things return `Ok(false)`/`Ok(None)` so the caller falls back to pickle (which *can* represent surrogate strings) — this path returned `Err` instead. It affected both **key** serialization (a surrogate argument) and **value** serialization (a surrogate return), including surrogates nested in tuples.

Memory backend is unaffected (it stores Python objects directly and never calls serde).

## Fix

Treat a non-UTF8-encodable string as unsupported by the fast path and return `Ok(false)`, so the caller falls back to pickle:

```rust
let Ok(s) = obj.cast::<PyString>()?.to_cow() else {
    return Ok(false);
};
```

Valid UTF-8 strings are unchanged — they take the identical fast path (no perf impact).

## Tests

Three regression tests on the shared backend (`tests/test_complex_objects.py`), each of which **fails with `UnicodeEncodeError` before the fix**:
- `test_surrogate_string_value` — surrogate as a return value
- `test_surrogate_string_key` — surrogate as an argument (cache-hit on second call)
- `test_surrogate_string_in_tuple_key` — surrogate nested in a tuple (key + value, tuple path)

## Gates

- `make lint` clean (ruff, ty, `cargo clippy -- -D warnings`); `cargo fmt --check` clean.
- `make test` — **89 passed** (86 baseline + 3 new).
- **Risky change** (touches `src/serde.rs`): serial matrix **3.10–3.13 — 89 passed each** (+ cargo 11). 3.14 skipped locally (uv resolves a stale 3.14.0a6 prerelease); CI covers real 3.14 finals.
- Skipped `make bench`: the change only alters the non-UTF8 fallback path; valid strings take the identical fast path.

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)