### PR TITLE
ci: add concurrency group and regression alerts to bench workflow

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -12,6 +12,13 @@ on:
 permissions:
   contents: read
 
+# Cancel an in-flight run when a newer master push starts — otherwise a batch of
+# merges stacks up full matrices that contend for the limited macOS/arm runners
+# and delay (or stall) the gated publish job.
+concurrency:
+  group: bench-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   bench:
     strategy:
@@ -85,4 +92,10 @@ jobs:
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: dev/bench
           auto-push: true
-          fail-on-alert: false # trend tracking only — never gate on noisy CI numbers
+          # Notify on a real regression (>=2x slower than the previous run) via a
+          # commit comment, but never fail the build — CI perf numbers are noisy.
+          # Tighten alert-threshold later if 200% proves too lax.
+          alert-threshold: "200%"
+          comment-on-alert: true
+          alert-comment-cc-users: "@toloco"
+          fail-on-alert: false


### PR DESCRIPTION
## Why

Two gaps in `.github/workflows/bench.yml` (see #69):

1. **No concurrency control** — every master push started a full 9-cell matrix with nothing cancelling older in-flight runs, so a batch of merges piled up and contended for the limited macOS/arm runners.
2. **No deviation alerting** — regressions were charted but never surfaced (`fail-on-alert: false`, no threshold/comment).

## Changes

- **Concurrency group** keyed on `github.ref` with `cancel-in-progress: true` — a newer master run cancels the older one.
- **Regression alerts** in the `github-action-benchmark` step, *without gating*:
  - `alert-threshold: "200%"` (~2× slower than the previous run)
  - `comment-on-alert: true`, `alert-comment-cc-users: "@toloco"`
  - `fail-on-alert: false` kept — CI perf is noisy on shared runners, so this **notifies** (commit comment) rather than blocks. Tighten the threshold later if 200% is too lax.

YAML validated; parsed structure confirmed (`concurrency` block + alert keys on the publish step).

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)