### PR TITLE
fix: run CI benchmark trend job warp_cache-only (cachebox hangs on 3.10/3.11)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -50,7 +50,9 @@ jobs:
       - name: Build extension
         run: uv run maturin develop --release
       - name: Run benchmarks (quick)
-        run: uv run python benchmarks/_bench_runner.py --tag "$TAG" --quick
+        # --warp-only: the trend dashboard charts only warp_cache, and a competitor
+        # lib that hangs (cachebox infinite-loops on 3.10/3.11) would stall the job.
+        run: uv run python benchmarks/_bench_runner.py --tag "$TAG" --quick --warp-only
       - name: Convert to action format
         run: uv run python benchmarks/_to_action_json.py "benchmarks/results/bench_$TAG.json" "bench-action-$TAG.json" --tag "$TAG"
       - uses: actions/upload-artifact@v4

--- a/benchmarks/_bench_runner.py
+++ b/benchmarks/_bench_runner.py
@@ -52,7 +52,7 @@ async def _async_identity(x: int) -> int:
     return x
 
 
-def _build_contestants() -> list[Contestant]:
+def _build_contestants(warp_only: bool = False) -> list[Contestant]:
     contestants: list[Contestant] = []
 
     # 1. warp_cache (always available — this is the project under test)
@@ -69,6 +69,12 @@ def _build_contestants() -> list[Contestant]:
             version="0.1.0",
         )
     )
+
+    # warp_only: skip the comparison libs entirely. The trend dashboard only
+    # charts warp_cache, and a competitor that hangs (e.g. cachebox infinite-
+    # looping on 3.10/3.11) would otherwise stall the whole CI bench job.
+    if warp_only:
+        return contestants
 
     # 2. functools.lru_cache (stdlib, always available)
     contestants.append(
@@ -641,10 +647,15 @@ def main() -> None:
     parser.add_argument("--tag", required=True, help="Label for this run (e.g. py3.12)")
     parser.add_argument("--quick", action="store_true", help="Skip sustained & TTL benchmarks")
     parser.add_argument("--rounds", type=int, default=3, help="Rounds per burst benchmark (median)")
+    parser.add_argument(
+        "--warp-only",
+        action="store_true",
+        help="Benchmark only warp_cache (skip comparison libs). Used by the CI trend job.",
+    )
     args = parser.parse_args()
 
     info = python_info()
-    contestants = _build_contestants()
+    contestants = _build_contestants(warp_only=args.warp_only)
     available = [c for c in contestants if c.available]
     unavailable = [c for c in contestants if not c.available]
 


### PR DESCRIPTION
## This is the fix that unblocks the benchmark dashboard

The "Benchmark trends" workflow has **never published** — `gh-pages`/the dashboard don't exist because the `bench` matrix never goes fully green: the **Python 3.10/3.11 cells hang** on the "Run benchmarks (quick)" step, so the gated `publish` job never runs.

## Root cause (reproduced locally)

Ran `--quick` on 3.10 with a faulthandler timeout — the hang is **inside the `cachebox` comparison library**, not warp_cache:

```
cachebox/_cachebox.py:941 in insert            <- stuck >90s
benchmarks/_bench_runner.py:240 in _time_loop
benchmarks/_bench_runner.py:309 in bench_throughput   (single-thread throughput)
```

`cachebox.insert` infinite-loops on 3.10/3.11 (fine on 3.12+) — hence the version-specific hang.

## Fix

The trend dashboard charts **only warp_cache** (`_to_action_json.py` reads only the `warp_cache` key from `throughput[1024]` and `threading[8]`), so the competitor libs are run in CI and discarded — pure hang risk. Add a **`--warp-only`** mode that benchmarks only warp_cache and use it in `bench.yml`'s run step. Competitors stay for local `make bench` / the comparison charts.

```diff
- run: uv run python benchmarks/_bench_runner.py --tag "$TAG" --quick
+ run: uv run python benchmarks/_bench_runner.py --tag "$TAG" --quick --warp-only
```

## Verification (on 3.10 — the version that hung)

`--warp-only --quick` **completes** (all 6 steps, including multiprocess — confirming the hang was cachebox, not warp_cache's shared memory) and the converter still emits the **2 dashboard metrics**. `ruff check`/`ruff format --check` clean; `_to_action_json --selftest` passes; `bench.yml` YAML validated.

## Follow-up (out of scope)

`cachebox` also hangs `make bench` locally on 3.10/3.11 — worth pinning/reporting upstream, but it doesn't block the dashboard.

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)