### PR TITLE
fix: serialize shared-cache creation to fix create/truncate race (#33)

### DIFF
--- a/src/shm/region.rs
+++ b/src/shm/region.rs
@@ -177,8 +177,27 @@ impl ShmRegion {
         ttl_nanos: u64,
     ) -> io::Result<Self> {
         let dir = shm_dir();
+        if !dir.exists() {
+            fs::create_dir_all(&dir)?;
+        }
         let data_path = dir.join(format!("{name}.data"));
         let lock_path = dir.join(format!("{name}.lock"));
+        let init_path = dir.join(format!("{name}.init"));
+
+        // Serialize creation across processes (#33). Without this, two cold-start
+        // creators can both fall through to create(), and the second's
+        // truncate+zero clobbers a region the first has already mapped — SIGBUS, or
+        // a torn read handing garbage back to Python. Hold an exclusive advisory
+        // lock on a dedicated .init file (never truncated) for the whole
+        // open-or-create decision; concurrent starters block here, then open the
+        // already-initialized file instead of racing into create().
+        let init_file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false) // never truncate — it's purely an advisory lock file
+            .open(&init_path)?;
+        init_file.lock()?;
 
         if data_path.exists() && lock_path.exists() {
             match Self::open_paths(&data_path, &lock_path) {
@@ -192,11 +211,11 @@ impl ShmRegion {
                     {
                         return Ok(region);
                     }
-                    // Parameters don't match — recreate
+                    // Parameters don't match — recreate (still under the init lock).
                     drop(region);
                 }
                 Err(_) => {
-                    // Stale or corrupted file — recreate
+                    // Stale or corrupted file — recreate (still under the init lock).
                 }
             }
         }
@@ -209,6 +228,7 @@ impl ShmRegion {
             max_value_size,
             ttl_nanos,
         )
+        // init_file's advisory lock is released when it drops at end of scope.
     }
 
     pub fn header(&self) -> &Header {

--- a/tests/test_shared_multiprocess.py
+++ b/tests/test_shared_multiprocess.py
@@ -8,6 +8,7 @@ import contextlib
 import glob
 import multiprocessing
 import os
+import queue
 import subprocess
 import sys
 import tempfile
@@ -25,6 +26,20 @@ def _cleanup_shm():
         for f in glob.glob(os.path.join(shm_dir, "*")):
             with contextlib.suppress(OSError):
                 os.unlink(f)
+
+
+def _shm_dir():
+    # Must match src/shm/region.rs::shm_dir: /dev/shm on Linux, $TMPDIR/warp_cache otherwise.
+    if sys.platform.startswith("linux"):
+        return "/dev/shm"
+    return os.path.join(tempfile.gettempdir(), "warp_cache")
+
+
+def _unlink_shm(name):
+    """Remove all files for a shm name so the next open is a cold create."""
+    for suffix in (".data", ".lock", ".init"):
+        with contextlib.suppress(OSError):
+            os.unlink(os.path.join(_shm_dir(), f"{name}{suffix}"))
 
 
 # Use a fixed shm_name so all processes (even with spawn) share the same cache
@@ -52,6 +67,25 @@ def _worker_read(x):
     return result, _shared_fn.cache_info().hits
 
 
+def _cold_start_worker(shm_name, barrier, q):
+    """Construct a fresh shared cache and exercise it. Run concurrently against
+    a cold (nonexistent) shm_name to race create_or_open (#33)."""
+    try:
+        barrier.wait(timeout=15)
+        fn = SharedCachedFunction(
+            lambda x: x * x,
+            32,
+            ttl=None,
+            max_key_size=512,
+            max_value_size=4096,
+            shm_name=shm_name,
+        )
+        ok = all(fn(i) == i * i for i in range(20))
+        q.put(bool(ok))
+    except BaseException as e:  # noqa: BLE001 - report any failure back to the parent
+        q.put(f"ERR:{e!r}")
+
+
 class TestMultiprocess:
     def setup_method(self):
         _cleanup_shm()
@@ -59,6 +93,42 @@ class TestMultiprocess:
 
     def teardown_method(self):
         _cleanup_shm()
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="No fork on Windows")
+    def test_concurrent_cold_start_no_corruption(self):
+        """Many processes cold-starting the SAME fresh cache at once must not
+        race in create_or_open (#33). Before the fix a second creator's
+        truncate+zero clobbered a region the first had already mapped, causing
+        SIGBUS (worker exits with a signal) or torn reads (wrong results)."""
+        ctx = multiprocessing.get_context("fork")
+        n_procs = 8
+        for round_i in range(4):
+            shm_name = f"test_cold_start_race_{round_i}"
+            _unlink_shm(shm_name)  # ensure a cold create
+            barrier = ctx.Barrier(n_procs)
+            q = ctx.Queue()
+            procs = [
+                ctx.Process(target=_cold_start_worker, args=(shm_name, barrier, q))
+                for _ in range(n_procs)
+            ]
+            for p in procs:
+                p.start()
+            for p in procs:
+                p.join(timeout=30)
+
+            exitcodes = [p.exitcode for p in procs]
+            results = []
+            with contextlib.suppress(queue.Empty):
+                while True:
+                    results.append(q.get_nowait())
+
+            assert all(c == 0 for c in exitcodes), (
+                f"round {round_i}: workers crashed (exitcodes={exitcodes}, results={results})"
+            )
+            assert len(results) == n_procs and all(r is True for r in results), (
+                f"round {round_i}: bad results {results}"
+            )
+            _unlink_shm(shm_name)
 
     @pytest.mark.skipif(sys.platform == "win32", reason="No fork on Windows")
     def test_cross_process_visibility(self):


### PR DESCRIPTION
## Problem

`ShmRegion::create_or_open` did a **non-atomic** `exists()`-then-`create()`. In the canonical multiprocessing scenario — N workers decorating the same function and cold-starting the shared cache simultaneously — two could both pass the `!exists()` check and enter `create()`, which does `truncate(true)` + `set_len` + `mmap.fill(0)` + re-inits the seqlock. The second creator's truncate/zero then clobbers a region the first has already mapped:

- **SIGBUS** if it touches the momentarily-truncated mapping, or
- a **torn read** (the reset seqlock makes a torn read validate as consistent) handing garbage back to Python.

Both are reachable from the safe Python API.

## Fix

Serialize the whole open-or-create decision with an **exclusive advisory file lock** on a dedicated `{name}.init` file (never truncated), held for the duration of `create_or_open`:

```rust
let init_file = OpenOptions::new().read(true).write(true).create(true).truncate(false).open(&init_path)?;
init_file.lock()?;   // std::fs::File::lock — Rust 1.89+, no new dependency
// ... open-and-validate, else create ...
// lock released when init_file drops at end of scope
```

Concurrent starters now block on the lock, then open the already-initialized file instead of racing into `create()`. `File::lock()` is per-open-file-description (flock on Unix / LockFileEx on Windows), so it serializes across processes **and** threads. No new crate — uses std.

## Test

`test_concurrent_cold_start_no_corruption`: 8 processes `Barrier`-synced onto the **same cold** `shm_name`, ×4 rounds, asserting no worker exits with a signal (SIGBUS) and every result is correct.

**Verified fails-before / passes-after:**
- With the fix: passes reliably (3/3 standalone + full suite ×6 across the matrix).
- Without the fix (stash + rebuild): the test **fails** — runs crashed/returned-wrong-results, and one run *deadlocked* (a dying creator wedging the others), so I had to stop it. Concrete proof of the race.

## Gates

- `make lint` (ruff, ty, `cargo clippy -- -D warnings`) clean; `cargo fmt --check` clean.
- `make test` — **90 passed**.
- **Risky change** (touches `src/shm/`): serial matrix **3.10–3.13 — 90 passed each** (+ cargo 11), race test green on every version. 3.14 skipped locally (uv's stale 3.14.0a6 prerelease); CI covers real 3.14.

## Scope note

This fixes the **primary, reported race** (concurrent cold-start). The secondary param-mismatch path (a process recreating with *different* `max_size`/`ttl` while another has the region mapped) is now serialized too, but truncating a live-mapped region on a genuine param change remains a deeper design question (versioned filenames) — worth a separate ticket if it matters in practice.

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)