### PR TITLE
fix: cross-process TTL broken on macOS — use system-wide CLOCK_MONOTONIC (#32)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -68,6 +68,11 @@ For day-to-day workflow and commands, see [`CLAUDE.md`](../CLAUDE.md) and
   `hash & (capacity - 1)`. Always use `.next_power_of_two()`.
 - **`#[repr(C)]` struct field ordering** — place u64 fields before u32 to avoid implicit
   alignment padding; affects `size_of` assertions in `layout.rs`.
+- **Cross-process timestamps must use a system-wide clock (issue #32).** `created_at_nanos`
+  is written into shared memory by one process and compared against `now` in another, so
+  `shm::current_time_nanos` uses `CLOCK_MONOTONIC` (process-independent on Linux, macOS, and
+  the BSDs). Never use `std::time::Instant` for shm timestamps — its epoch is per-process, so
+  the two bases are unrelated and TTL silently breaks across processes (the original macOS bug).
 - **No second shard guard while one is live (reentrancy, issue #30).** A memory-backend
   lookup runs arbitrary Python `__eq__` (via `PyObject_RichCompareBool`) *while a shard guard
   is held*. That `__eq__` can re-enter the same `CachedFunction` (or, on GIL builds, hand off

--- a/src/shm/mod.rs
+++ b/src/shm/mod.rs
@@ -525,35 +525,23 @@ pub struct ShmCacheInfo {
 }
 
 /// Get current monotonic time in nanoseconds.
+///
+/// Uses `CLOCK_MONOTONIC`, which is system-wide (process-independent) on Linux,
+/// macOS (Darwin), and the BSDs. This is required for correctness: `created_at_nanos`
+/// is written into shared memory by one process and compared against `now` in another
+/// (#32). `std::time::Instant` must NOT be used here — its epoch is per-process, so the
+/// subtraction would cross two unrelated time bases and silently break cross-process TTL.
+/// The shm module only compiles on non-Windows targets (see `lib.rs`), so `libc` and
+/// `CLOCK_MONOTONIC` are always available.
 fn current_time_nanos() -> u64 {
-    #[cfg(target_os = "macos")]
-    {
-        use std::time::Instant;
-        // Use a leaked base instant for consistent nanos
-        static BASE: std::sync::OnceLock<Instant> = std::sync::OnceLock::new();
-        let base = BASE.get_or_init(Instant::now);
-        base.elapsed().as_nanos() as u64
+    let mut ts = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    unsafe {
+        libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut ts);
     }
-
-    #[cfg(target_os = "linux")]
-    {
-        let mut ts = libc::timespec {
-            tv_sec: 0,
-            tv_nsec: 0,
-        };
-        unsafe {
-            libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut ts);
-        }
-        (ts.tv_sec as u64) * 1_000_000_000 + (ts.tv_nsec as u64)
-    }
-
-    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-    {
-        use std::time::Instant;
-        static BASE: std::sync::OnceLock<Instant> = std::sync::OnceLock::new();
-        let base = BASE.get_or_init(Instant::now);
-        base.elapsed().as_nanos() as u64
-    }
+    (ts.tv_sec as u64) * 1_000_000_000 + (ts.tv_nsec as u64)
 }
 
 // ShmCache is Send+Sync because all mutations go through the shm seqlock

--- a/tests/test_shared_multiprocess.py
+++ b/tests/test_shared_multiprocess.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 import tempfile
 import textwrap
+import time
 
 import pytest
 
@@ -176,6 +177,75 @@ class TestMultiprocess:
 
         info = _shared_fn.cache_info()
         assert info.current_size == 16  # still at capacity
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="No shared memory on Windows")
+    def test_cross_process_ttl_uses_systemwide_clock(self):
+        """An entry's TTL must be judged by a system-wide clock so a value
+        written by one process is aged correctly by another (#32).
+
+        The old macOS/non-Linux path timed entries with a per-process
+        ``Instant`` base, so ``created_at_nanos`` (written in the writer's base)
+        was compared against ``now`` in the reader's unrelated base. We force
+        the reader's clock base to be established well before the writer's, then
+        read immediately after the write: the entry is brand new (real age ~0,
+        ttl=1s) so it must be a HIT. Before the fix the base offset (~2s > ttl)
+        made it look long expired -> MISS. Linux already used CLOCK_MONOTONIC, so
+        this passes there before and after; it is the regression guard for macOS.
+        """
+        shm_name = "test_ttl_systemwide_clock"
+        _unlink_shm(shm_name)
+
+        # Reader: establish this process's clock base NOW (warmup insert), report
+        # READY, block until told to read, then read the writer's key.
+        reader_src = textwrap.dedent(f"""\
+            import sys
+            from warp_cache._warp_cache_rs import SharedCachedFunction
+
+            fn = SharedCachedFunction(
+                lambda x: x * x, 16, ttl=1.0,
+                max_key_size=512, max_value_size=4096, shm_name="{shm_name}",
+            )
+            fn(999)                       # warmup -> initializes this proc's clock base early
+            print("READY", flush=True)
+            sys.stdin.readline()          # wait until the writer has inserted key 7
+            val = fn.get(7)               # real age ~0 -> must be a HIT
+            print("HIT" if val is not None else "MISS", flush=True)
+        """)
+
+        # Writer: started >ttl after the reader's base, so its clock base is later.
+        writer_src = textwrap.dedent(f"""\
+            from warp_cache._warp_cache_rs import SharedCachedFunction
+
+            fn = SharedCachedFunction(
+                lambda x: x * x, 16, ttl=1.0,
+                max_key_size=512, max_value_size=4096, shm_name="{shm_name}",
+            )
+            assert fn(7) == 49            # insert key 7 with this proc's (late) base
+        """)
+
+        reader = subprocess.Popen(
+            [sys.executable, "-c", reader_src],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            assert reader.stdout.readline().strip() == "READY", "reader never warmed up"
+            # Gap > ttl: the writer's clock base ends up >1s after the reader's,
+            # which is exactly the offset that broke the pre-fix per-process timer.
+            time.sleep(2.0)
+            subprocess.run([sys.executable, "-c", writer_src], check=True, timeout=30)
+            reader.stdin.write("go\n")  # read now, right after the write (real age ~0)
+            reader.stdin.flush()
+            out, _ = reader.communicate(timeout=30)
+        finally:
+            if reader.poll() is None:
+                reader.kill()
+            _unlink_shm(shm_name)
+
+        assert out.strip().splitlines()[-1] == "HIT", (
+            f"cross-process TTL judged a fresh entry expired (stale clock base): {out!r}"
+        )
 
     @pytest.mark.skipif(sys.platform == "win32", reason="No shared memory on Windows")
     def test_cross_process_str_key_different_hashseed(self):


### PR DESCRIPTION
Closes #32

## What & why

The shared-memory backend timed cache entries with a **per-process** `std::time::Instant` base on macOS (and the non-Linux fallback). `created_at_nanos` is written into shared memory by one process but the TTL check (`now.saturating_sub(created_at) > ttl`) runs in **another** process whose `Instant` base has an unrelated origin. The subtraction crosses two time bases, so entries looked either arbitrarily far in the future (`saturating_sub` → 0, never expire) or already expired. TTL was effectively non-functional on macOS — the exact use case the cross-process backend exists for. Linux was already correct (it used `CLOCK_MONOTONIC`, which is system-wide).

## The fix

Collapse the three `#[cfg]` clock branches into a single `clock_gettime(CLOCK_MONOTONIC)` call. `CLOCK_MONOTONIC` is system-wide / process-independent on Linux, macOS (Darwin), and the BSDs, so timestamps are comparable across address spaces. The shm module only compiles on non-Windows targets (`lib.rs`), so `libc` and `CLOCK_MONOTONIC` are always available — no `cfg` needed. This also removes the identical latent bug in the old non-Linux fallback branch.

## Test

`tests/test_shared_multiprocess.py::test_cross_process_ttl_uses_systemwide_clock` spins up two independent processes and forces the **reader's** clock base to be established >ttl *before* the **writer's**, then reads immediately after the write (real age ≈ 0, `ttl=1s`):

- **before fix** (per-process `Instant`): base offset (~2s) > ttl → entry judged expired → `MISS`
- **after fix** (`CLOCK_MONOTONIC`): real age ≈ 0 → `HIT`

Verified locally by reverting just the Rust change: test returns `MISS`; with the fix, `HIT`.

## Gates run (risky change — touches `src/shm/`)

- `make fmt` / `make lint` (ruff, ty, clippy `-D warnings`) ✓
- `make test` — `cargo test` (11) + full pytest (91) ✓
- `make test-matrix` — Python 3.10–3.13 ✓ (3.14 skipped locally via the documented `uv`-resolves-stale-alpha guard; CI covers 3.14 final)
- `make bench` — no regression; TTL read path steady at ~7.4–7.6M ops/s, shared backend nominal

## Impact

Behavioral fix only, no public API change. `clock_gettime(CLOCK_MONOTONIC)` is a vDSO call (comparable cost to `Instant::elapsed`, which also reads the clock), so no perf impact on the TTL path. Also documents the cross-process-clock invariant in `docs/ARCHITECTURE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)