### PR TITLE
fix: async single-flight crashes across event loops — partition per loop (#35)

### DIFF
--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,5 +1,7 @@
 import asyncio
 import sys
+import threading
+import time
 
 import pytest
 
@@ -278,8 +280,12 @@ async def test_async_single_flight_different_keys():
         return x * 10
 
     results = await asyncio.gather(
-        slow_fn(1), slow_fn(2), slow_fn(3),
-        slow_fn(1), slow_fn(2), slow_fn(3),
+        slow_fn(1),
+        slow_fn(2),
+        slow_fn(3),
+        slow_fn(1),
+        slow_fn(2),
+        slow_fn(3),
     )
     assert results == [10, 20, 30, 10, 20, 30]
     assert call_count == 3
@@ -333,6 +339,52 @@ async def test_async_single_flight_cancellation():
     assert results == [10, 10, 10]
     # Leader was cancelled (count 1), then one waiter recomputed (count 2)
     assert call_count == 2
+
+
+def test_async_single_flight_across_event_loops():
+    """Single-flight state must be partitioned per event loop (#35).
+
+    asyncio.Event binds to the first loop that awaits it. With one shared
+    _inflight dict (no per-loop keying), a follower running in a *different*
+    loop — e.g. another thread calling asyncio.run — retrieves the leader's
+    Event and ``await event.wait()`` raises 'RuntimeError: ... is bound to a
+    different event loop'. Two threads each run their own loop and gather
+    concurrent same-key calls; staggered so loop A registers its leader first,
+    loop B then crashed on the shared Event before the fix.
+    """
+    call_count = 0
+    count_lock = threading.Lock()
+
+    @cache(max_size=128)
+    async def slow_fn(x):
+        nonlocal call_count
+        with count_lock:
+            call_count += 1
+        await asyncio.sleep(0.2)  # keep the leader in-flight across the stagger
+        return x * 10
+
+    results: dict[str, list[int]] = {}
+    errors: dict[str, str] = {}
+
+    def run_in_loop(label: str) -> None:
+        async def main() -> list[int]:
+            return await asyncio.gather(slow_fn(1), slow_fn(1), slow_fn(1))
+
+        try:
+            results[label] = asyncio.run(main())
+        except BaseException as e:  # noqa: BLE001 - capture cross-loop crash for the parent
+            errors[label] = repr(e)
+
+    t_a = threading.Thread(target=run_in_loop, args=("A",))
+    t_b = threading.Thread(target=run_in_loop, args=("B",))
+    t_a.start()
+    time.sleep(0.05)  # let loop A register its leader Event while it sleeps
+    t_b.start()
+    t_a.join(timeout=10)
+    t_b.join(timeout=10)
+
+    assert not errors, f"cross-loop single-flight crashed: {errors}"
+    assert results == {"A": [10, 10, 10], "B": [10, 10, 10]}
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="shared memory is Unix-only")

--- a/warp_cache/_decorator.py
+++ b/warp_cache/_decorator.py
@@ -64,9 +64,7 @@ class AsyncCachedFunction:
         self.__doc__ = getattr(fn, "__doc__", None)
 
     @staticmethod
-    def _make_inflight_key(
-        args: tuple[Any, ...], kwargs: dict[str, Any] | None
-    ) -> Any:
+    def _make_inflight_key(args: tuple[Any, ...], kwargs: dict[str, Any] | None) -> Any:
         if kwargs:
             return (args, tuple(sorted(kwargs.items())))
         return args
@@ -76,7 +74,15 @@ class AsyncCachedFunction:
         if hit:
             return cached
 
-        key = self._make_inflight_key(args, kwargs or None)
+        # Partition single-flight state per event loop. An asyncio.Event binds to
+        # the loop that first awaits it, so a follower running in a different loop
+        # (e.g. another thread's asyncio.run) must not reuse a leader's Event — doing
+        # so raises "RuntimeError: ... bound to a different event loop" (#35). The
+        # entry is always popped in `finally` while this loop is still running the
+        # coroutine, so the loop stays alive and its id() cannot be reused mid-flight.
+        # ponytail: dict ops are atomic under the GIL and keys are disjoint per loop;
+        # add a lock only if free-threaded builds become supported.
+        key = (id(asyncio.get_running_loop()), self._make_inflight_key(args, kwargs or None))
 
         while True:
             event = self._inflight.get(key)


### PR DESCRIPTION
Closes #35

## What & why

`AsyncCachedFunction` kept a single instance-shared `_inflight` dict mapping a call key → `asyncio.Event` for single-flight (dogpile) coalescing. But **`asyncio.Event` binds to the first event loop that awaits it.** When the same decorated coroutine was invoked concurrently from two loops — e.g. two threads each calling `asyncio.run`, or any thread-per-loop deployment — a follower in loop B retrieved the leader's Event (created/bound in loop A) and `await event.wait()` raised:

```
RuntimeError: <asyncio.locks.Event object ...> is bound to a different event loop
```

…crashing every follower in the second loop. The common single-loop path was unaffected, so this slipped through (no test used multiple loops).

## The fix

Fold the running loop's id into the in-flight key:

```python
key = (id(asyncio.get_running_loop()), self._make_inflight_key(args, kwargs or None))
```

Each loop now coordinates its own leader and its own loop-bound Event. Cross-loop calls no longer coalesce (each loop computes the value once) — which is the correct trade-off: the cache backend is thread-safe, and asyncio Events fundamentally can't be shared across loops. The entry is always popped in `finally` while the loop is still running the coroutine, so the loop can't be GC'd and its `id()` can't be reused mid-flight.

Single-loop coalescing, error/cancellation recovery, and all existing behavior are unchanged.

## Test

`tests/test_async.py::test_async_single_flight_across_event_loops` runs two threads, each with its own loop, gathering concurrent same-key calls, staggered so loop A registers its leader first:

- **before fix:** loop B crashes — `errors == {'B': "RuntimeError('... bound to a different event loop')"}`
- **after fix:** `results == {"A": [10,10,10], "B": [10,10,10]}`, no errors

Verified locally by stashing just the fix: test reproduces the exact `RuntimeError`; with the fix it passes.

## Gates run

- `make fmt` / `make lint` (ruff, ty, clippy) ✓
- `make test` — `cargo test` (11) + pytest (92, +1 new) ✓
- `make test-matrix` — Python 3.10–3.13 ✓, new test passes on every version (3.14 skipped locally via the documented `uv`-resolves-stale-alpha guard; CI covers 3.14 final)

Pure-Python change, no Rust touched and no public API change, so no bench/doc updates needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)