### PR TITLE
fix: data race in lock-free read path — make SlotHeader.visited atomic (#37)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,7 +67,11 @@ For day-to-day workflow and commands, see [`CLAUDE.md`](../CLAUDE.md) and
 - **Hash table capacity must be power-of-2** — bitmask probing uses
   `hash & (capacity - 1)`. Always use `.next_power_of_two()`.
 - **`#[repr(C)]` struct field ordering** — place u64 fields before u32 to avoid implicit
-  alignment padding; affects `size_of` assertions in `layout.rs`.
+  alignment padding; affects `size_of` assertions in `layout.rs`. Any field the lock-free
+  read path *writes* (currently only `SlotHeader.visited`) must be an atomic type accessed
+  with `Relaxed` — readers touch it without the write lock while writers reuse the slot, so a
+  plain field is a data race (issue #37). `AtomicU64` is layout-identical to `u64`, so this
+  doesn't change the cross-process layout.
 - **Cross-process timestamps must use a system-wide clock (issue #32).** `created_at_nanos`
   is written into shared memory by one process and compared against `now` in another, so
   `shm::current_time_nanos` uses `CLOCK_MONOTONIC` (process-independent on Linux, macOS, and

--- a/src/shm/layout.rs
+++ b/src/shm/layout.rs
@@ -3,6 +3,8 @@
 //! All structs use fixed-size fields and explicit padding so the
 //! layout is identical across compilations and processes.
 
+use std::sync::atomic::AtomicU64;
+
 /// Magic bytes at the start of the header to validate the mapping.
 pub const MAGIC: [u8; 8] = *b"FCACHE01";
 
@@ -79,8 +81,12 @@ pub struct SlotHeader {
     // 8-byte aligned group
     pub key_hash: u64,         // 0..8
     pub created_at_nanos: u64, // 8..16  (monotonic nanos)
-    pub visited: u64,          // 16..24 (SIEVE: 0=unvisited, 1=visited)
-    pub unique_id: u64,        // 24..32 (unused, kept for layout stability)
+    // SIEVE bit: 0=unvisited, 1=visited. Atomic because the lock-free reader sets it
+    // (no write lock) while a writer concurrently reuses the slot — a data race on a
+    // plain field (#37). AtomicU64 is layout-identical to u64 (same size/align), so the
+    // cross-process #[repr(C)] layout and zero-init (AtomicU64(0) == unvisited) are unchanged.
+    pub visited: AtomicU64, // 16..24
+    pub unique_id: u64,     // 24..32 (unused, kept for layout stability)
 
     // 4-byte aligned group
     pub occupied: u32,  // 32..36 (1 = occupied, 0 = free)

--- a/src/shm/mod.rs
+++ b/src/shm/mod.rs
@@ -251,8 +251,10 @@ impl ShmCache {
     /// Look up a key (by hash + serialized bytes). Returns a copy of the value bytes on hit.
     ///
     /// Uses optimistic seqlock reads. Fully lock-free: on hit, sets `visited=1`
-    /// via a direct store (idempotent, safe even if the slot is concurrently evicted
-    /// because the mmap memory remains valid).
+    /// via an atomic (Relaxed) store. The store runs without the write lock and races
+    /// a concurrent writer reusing the slot, so the field is atomic to avoid a data
+    /// race (#37). The store is idempotent; if the slot was just evicted/reused, the
+    /// worst case is a benign `visited=1` on a fresh entry (one extra SIEVE round).
     pub fn get(&self, key_hash: u64, key_bytes: &[u8]) -> ShmGetResult {
         let lock = self.lock();
 
@@ -260,14 +262,17 @@ impl ShmCache {
 
         match result {
             OptimisticResult::Hit { value, slot_index } => {
-                // SIEVE: mark as visited — lock-free, idempotent store
+                // SIEVE: mark as visited — lock-free, idempotent atomic store.
+                // ponytail: accept the benign policy skew on a racing reuse; gating the
+                // store on a key re-check would add a racy non-atomic compare for no
+                // correctness gain (returned value was already seqlock-validated).
                 unsafe {
                     let slot_size = self.header().slot_size;
                     let slot_ptr = self
-                        .slab_base_mut()
+                        .slab_base()
                         .add(slot_index as usize * slot_size as usize);
-                    let slot = &mut *(slot_ptr as *mut SlotHeader);
-                    slot.visited = 1;
+                    let slot = &*(slot_ptr as *const SlotHeader);
+                    slot.visited.store(1, AtomicOrdering::Relaxed);
                 }
 
                 // Stats: atomic, no lock needed
@@ -337,7 +342,7 @@ impl ShmCache {
             let slot = &mut *(slot_ptr as *mut SlotHeader);
             slot.value_len = value_bytes.len() as u32;
             slot.created_at_nanos = current_time_nanos();
-            slot.visited = 1;
+            slot.visited.store(1, AtomicOrdering::Relaxed);
 
             let value_dest = slot_ptr.add(SLOT_HEADER_SIZE + slot.key_len as usize);
             std::ptr::copy_nonoverlapping(value_bytes.as_ptr(), value_dest, value_bytes.len());
@@ -398,7 +403,7 @@ impl ShmCache {
         slot.key_len = key_bytes.len() as u32;
         slot.value_len = value_bytes.len() as u32;
         slot.created_at_nanos = current_time_nanos();
-        slot.visited = 0;
+        slot.visited.store(0, AtomicOrdering::Relaxed);
         slot.prev = SLOT_NONE;
         slot.next = SLOT_NONE;
         slot.unique_id = self.next_unique_id.fetch_add(1, AtomicOrdering::Relaxed);

--- a/src/shm/ordering.rs
+++ b/src/shm/ordering.rs
@@ -1,6 +1,8 @@
 /// Intrusive doubly-linked list and SIEVE eviction for shared memory.
 ///
 /// Uses prev/next indices stored in each slot header.
+use std::sync::atomic::Ordering;
+
 use super::layout::{Header, SlotHeader, SLOT_NONE};
 
 /// Get a reference to a slot header.
@@ -85,9 +87,9 @@ pub unsafe fn sieve_evict(header: &mut Header, slab_base: *mut u8, slot_size: u3
     let capacity = header.capacity;
     for _ in 0..capacity * 2 {
         let s = slot_mut(slab_base, slot_size, hand);
-        if s.visited != 0 {
+        if s.visited.load(Ordering::Relaxed) != 0 {
             // Second chance: clear visited bit, advance hand
-            s.visited = 0;
+            s.visited.store(0, Ordering::Relaxed);
             let next = s.next;
             hand = if next != SLOT_NONE {
                 next

--- a/tests/test_shared_multiprocess.py
+++ b/tests/test_shared_multiprocess.py
@@ -68,6 +68,37 @@ def _worker_read(x):
     return result, _shared_fn.cache_info().hits
 
 
+# Small capacity so that writer inserts constantly evict and *reuse* the slots
+# readers are touching — drives the lock-free visited store against slot reuse (#37).
+_race_fn = SharedCachedFunction(
+    lambda x: x * x,
+    64,
+    ttl=None,
+    max_key_size=512,
+    max_value_size=4096,
+    shm_name="test_visited_race",
+)
+
+
+def _race_worker(role, args, q):
+    """Reader verifies every get returns k*k; writer churns distinct keys to evict."""
+    try:
+        if role == "r":
+            hot_keys, iters = args
+            ok = all(
+                _race_fn(hot_keys[i % len(hot_keys)]) == hot_keys[i % len(hot_keys)] ** 2
+                for i in range(iters)
+            )
+            q.put(bool(ok))
+        else:
+            start, iters = args
+            for k in range(start, start + iters):
+                _race_fn(k)  # distinct cold keys force eviction/reuse of slots
+            q.put(True)
+    except BaseException as e:  # noqa: BLE001 - report any failure back to the parent
+        q.put(f"ERR:{e!r}")
+
+
 def _cold_start_worker(shm_name, barrier, q):
     """Construct a fresh shared cache and exercise it. Run concurrently against
     a cold (nonexistent) shm_name to race create_or_open (#33)."""
@@ -130,6 +161,44 @@ class TestMultiprocess:
                 f"round {round_i}: bad results {results}"
             )
             _unlink_shm(shm_name)
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="No fork on Windows")
+    def test_concurrent_get_during_eviction_no_corruption(self):
+        """Readers get() hot keys while writers insert enough distinct keys to
+        evict and reuse those slots (#37). The lock-free read path marks
+        ``visited`` on a slot a writer may be concurrently reinitializing; the
+        field is now atomic (Relaxed) so this is no longer a data race. Drive it
+        hard across processes and assert no worker crashes and every get returns
+        the correct value.
+
+        Note: on x86-64/ARM64 the pre-fix plain store was benign (an aligned
+        8-byte store can't tear), so this guards path consistency rather than
+        deterministically failing pre-fix; the fix removes the formal data race.
+        """
+        ctx = multiprocessing.get_context("fork")
+        _race_fn.cache_clear()
+        hot_keys = list(range(16))
+        q = ctx.Queue()
+        specs = [("r", (hot_keys, 4000)) for _ in range(4)] + [
+            ("w", (1000 + i * 5000, 5000)) for i in range(4)
+        ]
+        procs = [ctx.Process(target=_race_worker, args=(role, a, q)) for role, a in specs]
+        for p in procs:
+            p.start()
+        for p in procs:
+            p.join(timeout=60)
+
+        exitcodes = [p.exitcode for p in procs]
+        results = []
+        with contextlib.suppress(queue.Empty):
+            while True:
+                results.append(q.get_nowait())
+
+        assert all(c == 0 for c in exitcodes), (
+            f"worker crashed (exitcodes={exitcodes}, results={results})"
+        )
+        assert len(results) == len(specs), f"missing worker results: {results}"
+        assert all(r is True for r in results), f"reader saw a wrong value: {results}"
 
     @pytest.mark.skipif(sys.platform == "win32", reason="No fork on Windows")
     def test_cross_process_visibility(self):


### PR DESCRIPTION
Closes #37

## What & why

On a cache hit, the lock-free `get()` path wrote `slot.visited = 1` with a **plain store while holding no lock**, after the seqlock read had already returned (`src/shm/mod.rs`). A concurrent writer in `insert_inner` — running under the write lock — can be reusing that exact slot after a SIEVE eviction, reinitializing `key_hash`, `key_len`, `visited`, `prev`, `next` and the key/value bytes (`slot.visited = 0` at init). The reader's plain store then races **write/write** (and write/read) with the writer's plain stores to the same `SlotHeader`: a data race / UB under the Rust memory model.

## The fix

Change `SlotHeader.visited` from `u64` → `AtomicU64` and access it with `Relaxed` at every site:

| Site | Access |
|------|--------|
| `mod.rs` lock-free reader (hit) | `visited.store(1, Relaxed)` (now via `&SlotHeader`, not `&mut`) |
| `mod.rs` writer, update-in-place | `visited.store(1, Relaxed)` |
| `mod.rs` writer, new-slot init | `visited.store(0, Relaxed)` |
| `ordering.rs` SIEVE second-chance | `visited.load(Relaxed)` / `visited.store(0, Relaxed)` |

The store is idempotent, so `Relaxed` is sufficient. **`AtomicU64` is layout-identical to `u64`** (same size/align, transparent repr), so the `#[repr(C)]` cross-process layout and zero-init are unchanged — the `size_of::<SlotHeader>() == 64` compile-time assertion still holds, and `AtomicU64(0)` is the correct `unvisited` default for the zeroed mmap.

The residual **benign** effect — a slot reused mid-read can end up `visited=1` on a fresh entry, surviving one extra SIEVE round — is accepted. Gating the store on a key re-check would add a racy non-atomic compare for no correctness gain (the returned value was already seqlock-validated). Marked with a `ponytail:` comment.

## Test

`tests/test_shared_multiprocess.py::test_concurrent_get_during_eviction_no_corruption` — the issue's exact trigger: 4 reader processes `get()` hot keys while 4 writer processes churn distinct keys to evict/reuse those slots, with true cross-process parallelism on the shared mmap. Asserts no worker crashes (no SIGBUS/SIGSEGV) and every `get` returns the correct value.

**Honest note on "fail-before":** on x86-64/ARM64 an aligned 8-byte store can't tear, so the pre-fix code was *benign* in practice (the reviewer downgraded this to medium for that reason). A behavioral test therefore can't deterministically fail before the fix — this test guards **path consistency** under heavy contention, and the substantive change is that all `visited` accesses are now atomic (no data race under the memory model / TSan). The SIEVE unit tests + unchanged bench hit-rate confirm eviction behavior is preserved.

## Gates run (risky change — `src/shm/`, `#[repr(C)]` layout, concurrency)

- `make fmt` / `make lint` (ruff, ty, clippy `-D warnings`) ✓
- `make test` — `cargo test` (11, incl. layout `size_of` assertions) + pytest (93, +1 new) ✓
- `make test-matrix` — Python 3.10–3.13 ✓, new test passes on each (3.14 skipped locally via the documented `uv`-resolves-stale-alpha guard; CI covers 3.14 final)
- `make bench` — no regression: shared backend ~9.0M ops/s, hit-rate 72.9% (unchanged); `Relaxed` compiles to plain loads/stores on x86/ARM, no fence

🤖 Generated with [Claude Code](https://claude.com/claude-code)