### PR TITLE
fix: reject oversized max_size on shared backend — capacity*2 u32 overflow (#41)

### DIFF
--- a/src/shared_store.rs
+++ b/src/shared_store.rs
@@ -67,6 +67,17 @@ impl SharedCachedFunction {
                 "max_size must be >= 1 for the shared backend",
             ));
         }
+        // The hash table is sized at 2x capacity rounded up to a power of two, which
+        // must fit in u32 — so capacity itself must be <= 2^30 (#41). Reject larger
+        // values here, before the `as u32` cast below silently truncates a usize that
+        // doesn't fit (e.g. 2^32 -> a tiny cache) and before region.rs overflows
+        // `capacity * 2` (panic in debug, 1-bucket table in release).
+        const MAX_SHARED_MAX_SIZE: usize = 1 << 30;
+        if max_size > MAX_SHARED_MAX_SIZE {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "max_size must be <= {MAX_SHARED_MAX_SIZE} for the shared backend (got {max_size})"
+            )));
+        }
 
         let pickle = py.import("pickle")?;
         let pickle_dumps = pickle.getattr("dumps")?.unbind();

--- a/src/shm/region.rs
+++ b/src/shm/region.rs
@@ -54,8 +54,20 @@ impl ShmRegion {
             fs::create_dir_all(&dir)?;
         }
 
-        // Hash table must be power-of-2 for bitmask probing
-        let ht_capacity = (capacity * 2).next_power_of_two();
+        // Hash table must be power-of-2 for bitmask probing. `capacity * 2` and its
+        // next-power-of-two must both fit in u32, or the table is silently mis-sized
+        // (overflow panics in debug; in release `capacity * 2` wraps and rounds down to
+        // a 1-bucket table that drops inserts). Reject at the boundary, like capacity==0
+        // above, so the region can never be built mis-sized regardless of caller (#41).
+        let ht_capacity = capacity
+            .checked_mul(2)
+            .and_then(u32::checked_next_power_of_two)
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "shared cache capacity (max_size) too large: 2x hash table exceeds u32",
+                )
+            })?;
         let total_size = layout::region_size(capacity, ht_capacity, slot_size);
 
         let data_path = dir.join(format!("{name}.data"));

--- a/tests/test_shared_basic.py
+++ b/tests/test_shared_basic.py
@@ -358,3 +358,30 @@ class TestSharedMaxSizeZero:
 
         assert fn(3) == 6
         assert fn(3) == 6
+
+
+class TestSharedMaxSizeTooLarge:
+    """Regression for #41: max_size whose 2x hash table overflows u32 used to
+    panic across FFI (debug) or silently build a 1-bucket table that drops every
+    insert after the first (release). Both must now be a clean ValueError."""
+
+    def setup_method(self):
+        _cleanup_shm()
+
+    def teardown_method(self):
+        _cleanup_shm()
+
+    @pytest.mark.parametrize(
+        "max_size",
+        [
+            2**31,  # capacity*2 overflows u32 (the headline trigger)
+            2**32,  # also exercises the usize->u32 truncation path (would wrap to 0)
+            2**30 + 1,  # just past the largest table that fits in u32
+        ],
+    )
+    def test_oversized_max_size_raises(self, max_size):
+        with pytest.raises(ValueError, match="max_size must be <="):
+
+            @cache(max_size=max_size, backend="shared")
+            def fn(x):
+                return x


### PR DESCRIPTION
Closes #41

## What & why

The shared backend sizes its hash table as `(capacity * 2).next_power_of_two()` in `region.rs`, where `capacity: u32` comes from `max_size as u32`. Two reachable problems from `@cache(max_size=…, backend="shared")`:

1. **Overflow (the headline):** for `max_size >= 2^31`, `capacity * 2` overflows u32.
   - **Debug:** panics (`attempt to … with overflow`) and unwinds across the FFI boundary.
   - **Release:** wraps → `next_power_of_two` rounds down to a **1-bucket** table. After the first insert the bucket is full, and every subsequent insert is silently dropped (`ht_insert`'s "full" `debug_assert!` is compiled out) — a multi-billion-entry cache that holds one entry, violating the 2x-capacity / 50%-load invariant.
2. **Silent truncation:** `max_size as u32` truncates a `usize > u32::MAX` (e.g. `2^32` → `0`).

## The fix

Reject `max_size > 2^30` in the `SharedCachedFunction` constructor with a clear `ValueError`. `2^30` is the largest capacity whose `2x` power-of-two `ht_capacity` (= `2^31`) still fits in `u32`. Validating the `usize` *before* the `as u32` cast also closes the truncation hole.

As defense-in-depth for any caller (mirroring the existing `capacity == 0` guard from #31), `region.rs` now computes:

```rust
let ht_capacity = capacity
    .checked_mul(2)
    .and_then(u32::checked_next_power_of_two)
    .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "… too large: 2x hash table exceeds u32"))?;
```

so the region can never be built mis-sized, regardless of how it's reached.

## Test

`TestSharedMaxSizeTooLarge::test_oversized_max_size_raises` — parametrized over `2^31` (overflow trigger), `2^32` (truncation path), and `2^30 + 1` (just past the largest table that fits in u32). Each must raise `ValueError`.

Verified fail-before → pass-after on the buggy build: all three raised `pyo3_runtime.PanicException: attempt to … with overflow` (or `PyOSError`, for the truncation case) instead of `ValueError`; with the fix, all three raise `ValueError`. All three are rejected **before any allocation**, so the test is cheap and can't touch the multi-TB slab path.

## Gates run (risky change — `src/shm/region.rs`)

- `make fmt` / `make lint` (ruff, ty, clippy `-D warnings`) ✓
- `make test` — `cargo test` (11) + pytest (96, +3 new) ✓
- `make test-matrix` — Python 3.10–3.13 ✓ (3.14 skipped locally via the documented `uv`-resolves-stale-alpha guard; CI covers 3.14 final)
- `make bench` — no regression (validation is construction-time only): shared backend ~9.7M ops/s, hit-rate 72.9%

🤖 Generated with [Claude Code](https://claude.com/claude-code)