### PR TITLE
fix: validate ttl_nanos when reusing a shared region across processes (#42)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,7 +67,11 @@ For day-to-day workflow and commands, see [`CLAUDE.md`](../CLAUDE.md) and
 - **Hash table capacity must be power-of-2** — bitmask probing uses
   `hash & (capacity - 1)`. Always use `.next_power_of_two()`.
 - **`#[repr(C)]` struct field ordering** — place u64 fields before u32 to avoid implicit
-  alignment padding; affects `size_of` assertions in `layout.rs`.
+  alignment padding; affects `size_of` assertions in `layout.rs`. Any field the lock-free
+  read path *writes* (currently only `SlotHeader.visited`) must be an atomic type accessed
+  with `Relaxed` — readers touch it without the write lock while writers reuse the slot, so a
+  plain field is a data race (issue #37). `AtomicU64` is layout-identical to `u64`, so this
+  doesn't change the cross-process layout.
 - **Seqlock writer ordering (issue #40).** The writer must publish the odd ("writer active")
   sequence number *before* its data mutations become visible: `write_lock` does the odd store
   then an `atomic::fence(Release)` (a Release store alone orders only *prior* ops). This pairs
@@ -75,16 +79,17 @@ For day-to-day workflow and commands, see [`CLAUDE.md`](../CLAUDE.md) and
   weak-memory hardware a data write can float ahead of the odd publish and a reader can validate
   a torn read against a stale even seq. The ordering is model-checked under `loom` (run
   `RUSTFLAGS="--cfg loom" cargo test --lib seqlock_ordering`; loom is a `cfg(loom)`-only dep).
-  alignment padding; affects `size_of` assertions in `layout.rs`. Any field the lock-free
-  read path *writes* (currently only `SlotHeader.visited`) must be an atomic type accessed
-  with `Relaxed` — readers touch it without the write lock while writers reuse the slot, so a
-  plain field is a data race (issue #37). `AtomicU64` is layout-identical to `u64`, so this
-  doesn't change the cross-process layout.
 - **Cross-process timestamps must use a system-wide clock (issue #32).** `created_at_nanos`
   is written into shared memory by one process and compared against `now` in another, so
   `shm::current_time_nanos` uses `CLOCK_MONOTONIC` (process-independent on Linux, macOS, and
   the BSDs). Never use `std::time::Instant` for shm timestamps — its epoch is per-process, so
   the two bases are unrelated and TTL silently breaks across processes (the original macOS bug).
+- **All behavior-affecting header config gates region reuse (issue #42).** When a process opens
+  an existing shm region, `region.rs::create_or_open` reuses it only if `version`, `capacity`,
+  `max_key_size`, `max_value_size`, **and `ttl_nanos`** all match; any mismatch recreates the
+  region. TTL lives in the shared header and governs expiry for every reader, so a new header
+  field that changes behavior must be added to this reuse check too — otherwise a process opening
+  with a different value silently inherits the creator's, producing config-dependent behavior.
 - **No second shard guard while one is live (reentrancy, issue #30).** A memory-backend
   lookup runs arbitrary Python `__eq__` (via `PyObject_RichCompareBool`) *while a shard guard
   is held*. That `__eq__` can re-enter the same `CachedFunction` (or, on GIL builds, hand off

--- a/src/shm/region.rs
+++ b/src/shm/region.rs
@@ -214,12 +214,18 @@ impl ShmRegion {
         if data_path.exists() && lock_path.exists() {
             match Self::open_paths(&data_path, &lock_path) {
                 Ok(region) => {
-                    // Validate parameters match
+                    // Validate parameters match. ttl_nanos is included (#42): TTL
+                    // lives in the shared header and governs expiry for every process
+                    // (shm/mod.rs reads h.ttl_nanos at lookup time), so a process
+                    // opening with a different TTL must recreate rather than silently
+                    // inherit the creator's TTL — same last-writer-wins recreate as the
+                    // other config params.
                     let header = region.header();
                     if header.version == VERSION
                         && header.capacity == capacity
                         && header.max_key_size == max_key_size
                         && header.max_value_size == max_value_size
+                        && header.ttl_nanos == ttl_nanos
                     {
                         return Ok(region);
                     }

--- a/tests/test_shared_basic.py
+++ b/tests/test_shared_basic.py
@@ -303,6 +303,46 @@ class TestSharedTTL:
         assert fn.cache_info().hits == 1
 
 
+class TestSharedTTLConfigMismatch:
+    """Regression for #42: opening an existing shm region with a different TTL
+    used to silently reuse the creator's region (and its TTL stored in the
+    header), ignoring the second caller's requested TTL. A TTL mismatch must now
+    recreate the region, just like a capacity/key/value-size mismatch."""
+
+    def setup_method(self):
+        _cleanup_shm()
+
+    def teardown_method(self):
+        _cleanup_shm()
+
+    def test_ttl_mismatch_recreates_region(self):
+        import time
+
+        from warp_cache._warp_cache_rs import SharedCachedFunction
+
+        shm_name = "test_ttl_mismatch_42"
+
+        # First constructor fixes the region's TTL to 0.1s.
+        SharedCachedFunction(
+            lambda x: x, 16, ttl=0.1, max_key_size=512, max_value_size=4096, shm_name=shm_name
+        )
+
+        # Second constructor requests ttl=None on the same region. After the fix
+        # the TTL mismatch recreates the region with no TTL; before the fix it
+        # silently reused the first region and honored ttl=0.1.
+        fn_b = SharedCachedFunction(
+            lambda x: x, 16, ttl=None, max_key_size=512, max_value_size=4096, shm_name=shm_name
+        )
+
+        assert fn_b(1) == 1  # miss -> store
+        time.sleep(0.3)  # well past the first constructor's 0.1s TTL
+        assert fn_b(1) == 1  # ttl=None -> still a hit; ttl=0.1 (bug) -> expired miss
+        assert fn_b.cache_info().hits == 1, (
+            "second constructor's ttl=None was ignored — entry expired per the "
+            "first constructor's ttl=0.1 (region was reused, not recreated)"
+        )
+
+
 class TestSharedMemoryBackend:
     """Test backend='memory' vs backend='shared' routing."""
 


### PR DESCRIPTION
Closes #42

## What & why

`region.rs::create_or_open` decides whether to reuse an existing shm region by comparing `version`, `capacity`, `max_key_size`, and `max_value_size` — but **not `ttl_nanos`**. TTL lives in the shared header and is read at lookup time (`shm/mod.rs`: `h.ttl_nanos`), governing expiry for *every* process. So when process B opens a cache that process A created with a different TTL:

- A: `cache(backend="shared", ttl=10)(f)`
- B (same `shm_name`): `cache(backend="shared", ttl=None)(f)` → silently reuses A's region; B's entries expire per **ttl=10**, not None.

Same decorator params → different effective behavior depending on who won the create race, and inconsistent with the other config params (which already force a recreate on mismatch).

## The fix

Add `header.ttl_nanos == ttl_nanos` to the reuse condition, so a TTL mismatch recreates the region — same last-writer-wins behavior as a capacity/key/value-size mismatch.

## Test

`TestSharedTTLConfigMismatch::test_ttl_mismatch_recreates_region`: construct a region with `ttl=0.1`, then construct again on the same `shm_name` with `ttl=None`; an entry stored by the second must survive past 0.1s. The bug lives in the reuse decision (hit on the *second* construction, same code path in-process or cross-process), so a single-process test covers it deterministically.

Verified fail-before → pass-after by stashing just the fix: buggy build gave `hits=0, misses=2` (entry expired per the creator's `ttl=0.1`); with the fix, `hits=1`.

## Drive-by doc fix (disclosed)

While adding the #42 invariant I found a **merge artifact** in `docs/ARCHITECTURE.md`: the issue #37 invariant text had been stranded as a duplicated `alignment padding; …` fragment *after* the #40 bullet (a result of #76 and #77 landing together). I folded it back into the `#[repr(C)]` bullet where it belongs. Pure docs, no behavior — happy to split into its own PR if you'd prefer.

## Gates run (risky change — `src/shm/region.rs`)

- `make fmt` / `make lint` (ruff, ty, clippy `-D warnings`) ✓
- `make test` — `cargo test` (11) + pytest (102, +1 new) ✓
- `make test-matrix` — Python 3.10–3.13 ✓, new test passes on each (3.14 skipped locally via the documented `uv`-resolves-stale-alpha guard; CI covers 3.14 final)
- `make bench` — no regression (construction-time-only change): shared backend ~9.4M ops/s, hit-rate 72.9%

🤖 Generated with [Claude Code](https://claude.com/claude-code)